### PR TITLE
Ubuntu version update

### DIFF
--- a/gpodder.py
+++ b/gpodder.py
@@ -65,8 +65,8 @@ else:
     releases = {
         "bionic": debian_dir,
         "focal": debian_dir,
-        "hirsute": debian_dir,
         "impish": debian_dir,
+        "jammy": debian_dir,
     }
 
 for release, debian_dir in releases.items():


### PR DESCRIPTION
Updates ubuntu versions list by adding `jammy` (22.04 LTS) and removing `hirsute`, which is EOL since January, in preparation for a new gPodder release.

After the new version is released, the context for both
- `debian_gpodder/patches/remove_copyright_character.patch`
- `debian_gpodder_stable/patches/remove_copyright_character.patch`

will have to be changed again, as well as the version number in `gpodder.py`.